### PR TITLE
fix: add apt update before package installation

### DIFF
--- a/.chezmoiscripts/run_onchange_before_01_install_apt_packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_01_install_apt_packages.sh.tmpl
@@ -1,4 +1,5 @@
 {{- if eq .chezmoi.os "linux" -}}
 #!/bin/bash
+sudo apt update
 sudo apt install -y {{ range .packages.linux.apt }} {{- . }} {{ end }}
 {{- end }}


### PR DESCRIPTION
### 概要

GitHub Actions の ubuntu-latest 環境で発生していた apt パッケージインストールエラーを修正する。

### 背景

PR #108 において、GitHub Actions の ubuntu-latest 環境で `uuid-dev` パッケージの取得に失敗し、以下のエラーが発生していた。

```
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/u/util-linux/uuid-dev_2.39.3-9ubuntu6.2_amd64.deb  404  Not Found
```

この問題は、パッケージリストが古いため、依存関係として自動的に追加される `uuid-dev` パッケージの最新バージョンを取得できないことが原因であった。

### 目的

chezmoi のスクリプト実行時に apt パッケージの最新情報を取得し、GitHub Actions でのパッケージインストールエラーを解決する。

### 実装内容

`.chezmoiscripts/run_onchange_before_01_install_apt_packages.sh.tmpl` に `sudo apt update` を追加し、パッケージリストを更新してからインストールを実行するように修正した。

これにより、利用可能な最新バージョンのパッケージを取得でき、404 エラーを回避できる。

🤖 Generated with [Claude Code](https://claude.ai/code)