### PR TITLE
groomed の Git commit 署名を Secure Enclave 鍵に移行する

### DIFF
--- a/hosts/groomed/default.nix
+++ b/hosts/groomed/default.nix
@@ -26,9 +26,6 @@ in
 
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
-  home-manager.extraSpecialArgs = {
-    gitSigningKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIeDWRbheAOzb7QoPZJdlH9ACbvFqBOHq9RzBTK3UmWe";
-  };
   home-manager.users.${username} = {
     imports = [
       ../../modules/home

--- a/modules/profiles/darwin.nix
+++ b/modules/profiles/darwin.nix
@@ -1,27 +1,70 @@
 {
   config,
   pkgs,
-  gitSigningKey,
+  lib,
   ...
 }:
 
 let
   onePasswordAgent = "${config.home.homeDirectory}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+
+  # Apple's ssh-keygen is required: it can load /usr/lib/ssh-keychain.dylib
+  # as an SK provider, which nixpkgs openssh is not verified to do.
+  sshKeygenSecureEnclave = pkgs.writeShellApplication {
+    name = "ssh-keygen-secure-enclave";
+    text = ''
+      export SSH_SK_PROVIDER=/usr/lib/ssh-keychain.dylib
+      exec /usr/bin/ssh-keygen "$@"
+    '';
+  };
+
+  # One-shot bootstrap; run manually once after switch.
+  # Not an activation script: sc_auth touches Secure Enclave / keychain and
+  # can silently fail outside the user's GUI security session, and failures
+  # are easier to recover interactively (sc_auth delete-ctk-identity -l git-sign).
+  bootstrapGitSigningKey = pkgs.writeShellApplication {
+    name = "bootstrap-git-signing-key";
+    text = ''
+      key="$HOME/.ssh/id_git_sign"
+      if [ -f "$key" ]; then
+        echo "Already bootstrapped: $key"
+        exit 0
+      fi
+      if ! sc_auth list-ctk-identities 2>/dev/null | grep -q 'git-sign'; then
+        sc_auth create-ctk-identity -l git-sign -k p-256-ne -t none
+      fi
+      tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
+      (
+        cd "$tmp" || exit 1
+        # -K writes ALL resident keys into CWD, hence the temp dir.
+        SSH_SK_PROVIDER=/usr/lib/ssh-keychain.dylib /usr/bin/ssh-keygen -K -N ""
+      )
+      mkdir -p "$HOME/.ssh"
+      mv "$tmp"/id_ecdsa_sk_rk "$key"
+      mv "$tmp"/id_ecdsa_sk_rk.pub "$key.pub"
+      chmod 600 "$key"
+      echo "Register this key on GitHub as a signing key:"
+      cat "$key.pub"
+    '';
+  };
 in
 {
-  home.packages = with pkgs; [
-    _1password-cli
-    docker-client
-    docker-credential-helpers
-    coreutils
-    diffutils
-    findutils
-    gawk
-    gnugrep
-    gnused
-    gnutar
-    hackgen-nf-font
-  ];
+  home.packages =
+    (with pkgs; [
+      _1password-cli
+      docker-client
+      docker-credential-helpers
+      coreutils
+      diffutils
+      findutils
+      gawk
+      gnugrep
+      gnused
+      gnutar
+      hackgen-nf-font
+    ])
+    ++ [ bootstrapGitSigningKey ];
 
   programs.ghostty = {
     enable = true;
@@ -45,8 +88,8 @@ in
 
   programs.git.signing = {
     format = "ssh";
-    signer = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
-    key = gitSigningKey;
+    signer = lib.getExe sshKeygenSecureEnclave;
+    key = "${config.home.homeDirectory}/.ssh/id_git_sign";
     signByDefault = true;
   };
 


### PR DESCRIPTION
### 概要

groomed(macOS)の Git commit 署名を、1Password 経由の SSH 署名(op-ssh-sign)から Secure Enclave の鍵による署名に切り替える。
1Password 署名は生体認証を要求するため、coding agent がタスク中に commit すると生体認証待ちでタイムアウトしていた。
Secure Enclave 側の鍵は生体認証不要(`-t none`)かつ non-exportable な鍵として作成し、`~/.ssh/id_git_sign` にはその鍵への参照(key handle)のみを置く。

### 背景

- 1Password 経由の署名は commit のたびに生体認証を要求する。
- coding agent がタスク中に commit を行う場面では、生体認証の入力待ちが発生し、タイムアウトで失敗する問題があった。
- 参考記事: https://www.mizdra.net/entry/2026/08/07/101542

### 目的

生体認証を要求しない署名方式に切り替えることで、coding agent が生体認証待ちでタイムアウトせずに commit できるようにする。

### 実装内容

- `modules/profiles/darwin.nix` に以下を追加した。
  - `ssh-keygen-secure-enclave`: `SSH_SK_PROVIDER` に Apple の `ssh-keychain.dylib` を指定し、Apple 版 `ssh-keygen` を呼び出すラッパー。nixpkgs の openssh は同 provider を読み込めることが確認されていないため、Apple のバイナリを使う。
  - `bootstrap-git-signing-key`: Secure Enclave 上に `git-sign` という label の CTK identity(`p-256-ne`、`-t none`)を作成し、resident key を `~/.ssh/id_git_sign` として書き出す one-shot スクリプト。Secure Enclave やキーチェーンへのアクセスは GUI セキュリティセッションの外では失敗し得るため、Home Manager のアクティベーションスクリプトにはせず、手動実行するコマンドとして `home.packages` に追加した。
  - `programs.git.signing` の `signer` を `ssh-keygen-secure-enclave` に、`key` を `~/.ssh/id_git_sign` に変更した。
- `hosts/groomed/default.nix` から `home-manager.extraSpecialArgs.gitSigningKey` を削除した。darwin.nix が鍵の値を引数として受け取る必要がなくなったため。
- powder(NixOS-WSL)は対象外とし、1Password 署名を継続する。WSL2 には TPM パススルーがなく(microsoft/WSL#10777)、Secure Enclave 相当の方式が取れないため。
- SSH 認証まわり(1Password agent、IdentityAgent、SSH_AUTH_SOCK)は変更していない。

### 適用後に groomed で必要な手順

`make switch` を実行した直後、`bootstrap-git-signing-key` を一度だけ実行して Secure Enclave 上に鍵を作成し、出力された公開鍵を GitHub の signing key として登録する必要がある。
この手順を実行するまでの間は commit の署名が失敗する窓があることに注意する。
GitHub 上に登録済みの旧鍵(1Password 側の鍵)の signing key 登録は、過去の commit の Verified 表示を維持するために削除しないこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
